### PR TITLE
Mudar redirecionamento do pop-up para front

### DIFF
--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -5,14 +5,16 @@ export const AuthCallback = () => {
     const params = new URLSearchParams(window.location.search);
     const code = params.get('code');
     const state = params.get('state');
+    const iss = params.get('iss');
 
-    if (code && state && window.opener) {
+    if (code && state && iss && window.opener) {
       // Envia os dados para a aba principal
       window.opener.postMessage(
         {
           type: 'login-success',
           code,
           state,
+          iss
         },
         window.location.origin
       );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -39,7 +39,7 @@ export const HomePage = () => {
         myHeaders.append('Content-Type', 'application/json');
 
         const raw = JSON.stringify({
-            redirectUrl: 'http://34.10.196.166:3000/auth/callback',
+            redirectUrl: window.location.origin + '/auth/callback',
         });
 
         const requestOptions: RequestInit = {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -16,18 +16,53 @@ export const HomePage = () => {
 
         const handleMessage = (event: MessageEvent) => {
             if (event.data?.type === 'login-success') {
-                const { sessionId, code, state } = event.data;
+                const { code, state, iss } = event.data;
                 console.log('Login recebido da aba externa:');
-                console.log('Session ID:', sessionId);
+                //console.log('Session ID:', sessionId);
                 console.log('Code:', code);
                 console.log('State:', state);
+                console.log('Iss: ', iss);
 
                 localStorage.setItem('code', code);
                 localStorage.setItem('state', state);
 
+                postCallback(code, state, iss);
+
                 const redirectPath = localStorage.getItem('redirectAfterLogin') || '/dashboard';
                 navigate(redirectPath);
             }
+        };
+
+        const postCallback = async (code: string, state: string, iss: string) => {
+
+            const myHeaders = new Headers();
+              myHeaders.append('Content-Type', 'application/json');
+              myHeaders.append('session-id', localStorage.getItem('sessionId') || '');
+        
+              const raw = JSON.stringify({
+                code,
+                state,
+                iss,
+              });
+        
+              const requestOptions: RequestInit = {
+                method: 'POST',
+                headers: myHeaders,
+                body: raw,
+                redirect: 'follow',
+            };
+        
+              try{
+        
+                const response = await fetch("http://34.10.196.166:3000/auth/callback", requestOptions); 
+                console.log("Dados recebidos do servidor:", response);
+        
+              } catch (error) {
+        
+                console.error('Erro ao enviar dados para o servidor:', error);
+        
+              }
+        
         };
 
         window.addEventListener('message', handleMessage);


### PR DESCRIPTION
Ao invés de redirecionar usuário para "backend/auth/callback" (efetivamente um GET), redireciona usuário para "frontend/auth/callback" que também faz um POST request para "backend/auth/callback" com header session-id.